### PR TITLE
Enable mouse in tmux2.2

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -137,10 +137,11 @@ set-window-option -g automatic-rename off # ウィンドウ名が自動的に更
 # http://blog.uguis.org/2011/08/mactmux-vim.html
 
 ## scroll option
-#set-window-option -g mode-mouse off
-# http://qiita.com/vintersnow/items/2880cc7b63a93a4d1b1d
-set-window-option -g mouse on
-set -g terminal-overrides 'xterm*:smcup@:rmcup@'
+# see: http://qiita.com/vintersnow/items/2880cc7b63a93a4d1b1d
+# see: http://qiita.com/polamjag/items/4a85aa09e49f8724dcea
+if-shell 'test $(echo "$(tmux -V | awk \{print\ \$2\}) > 2.0" | bc) -ne 0' \
+  'source-file ~/.tmux.d/mouse-after-2.1.conf' \
+  'source-file ~/.tmux.d/mouse-before-2.0.conf'
 
 ## for iterm2
 set -g default-terminal "xterm"

--- a/.tmux.d/mouse-after-2.1.conf
+++ b/.tmux.d/mouse-after-2.1.conf
@@ -1,0 +1,3 @@
+set-window-option -g mouse on
+bind -n WheelUpPane   select-pane -t= \; copy-mode -e \; send-keys -M
+bind -n WheelDownPane select-pane -t= \;                 send-keys -M

--- a/.tmux.d/mouse-before-2.0.conf
+++ b/.tmux.d/mouse-before-2.0.conf
@@ -1,0 +1,4 @@
+## tmp
+set-window-option -g mode-mouse off
+# set-window-option -g mouse on
+# set -g terminal-overrides 'xterm*:smcup@:rmcup@'


### PR DESCRIPTION
## 概要
tmux2.1以降でマウスが有効にならない問題の修正

## 変更点

- tmux.d ディレクトリの追加
- 2.1とそれ以前で別のファイルを読むように変更

## チェックリスト
- [x] 動作確認
  - iterm2 + tmux2.2

----

### 関連LINK
<!-- option -->
<!-- 関連するもの(CVE, issue)などはここに列挙-->

- [tmux 2.1 以降でもマウスを有効にする方法 - Qiita](http://qiita.com/polamjag/items/4a85aa09e49f8724dcea "tmux 2.1 以降でもマウスを有効にする方法 - Qiita")