### PR TITLE
Delete launchd.conf since this file is used for Golang in legacy envinment

### DIFF
--- a/etc/mac/launchd.conf
+++ b/etc/mac/launchd.conf
@@ -1,3 +1,0 @@
-/bin/launchctl setenv PATH   /usr/local/bin:$PATH
-/bin/launchctl setenv GOROOT /usr/local/go
-/bin/launchctl setenv GOPATH /Users/callistoiv/go


### PR DESCRIPTION
## Overview
This pull request removes the `launchd.conf` file that was previously used to set environment variables for Go development on macOS. The file is no longer needed, likely due to changes in how environment variables are managed or a migration to a different setup.
