### PR TITLE
Sync .zshrc

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,2 +1,4 @@
 config:
+  MD013:
+    line_length: 120
   MD034: false

--- a/.zshrc
+++ b/.zshrc
@@ -107,9 +107,6 @@ prompt paradox
 
 # Customize to your needs...
 export PATH=$HOME/bin:$PATH
-export PATH="/usr/local/opt/python/libexec/bin:$PATH"
-export PATH="$HOME/.embulk/bin:$PATH"
-export PATH=$HOME/go/bin:$PATH
 
 alias ga="git add"
 alias gc="git commit"
@@ -133,7 +130,7 @@ function peco-select-history() {
 }
 zle -N peco-select-history
 bindkey '^r' peco-select-history
-source <(kubectl completion zsh)
+# source <(kubectl completion zsh)
 #
 # tmux
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -9,39 +9,62 @@
 if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
 fi
-
 autoload -Uz promptinit
 promptinit
-prompt paradox
+# prompt paradox
+# prompt sorin
+prompt powerlevel10k
 
 # Customize to your needs...
+# Get the current operating system
+os_name=$(uname -s)
+
+# Common settings for all operating systems
+
+# OS-specific settings using case statement
+case $os_name in
+    Darwin)
+        # Add macOS-specific configurations here
+        # For asdf
+        export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+        # append completions to fpath
+        fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)
+
+        test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
+        ;;
+    Linux)
+        # Add Linux-specific configurations here
+        . "$HOME/.asdf/asdf.sh"
+        export PATH="$HOME/.asdf/bin:$PATH"
+        # append completions to fpath
+        fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)
+        ;;
+    # FreeBSD)
+    #     # FreeBSD settings
+    #     # Add FreeBSD-specific configurations here
+    #     ;;
+    *)
+        # Default settings for other operating systems
+        # echo "Default settings for other OS"
+        # Add default configurations here
+        ;;
+esac
+
 export PATH=$HOME/bin:$PATH
 
+# see: https://unix.stackexchange.com/questions/273861/unlimited-history-in-zsh
+export HISTSIZE=10000000
+export SAVEHIST=10000000
+
 alias ga="git add"
+alias gp="git pull"
 alias gc="git commit"
 alias gs="git status -sb"
 alias gd="git diff"
 alias gdc="git diff --cached"
 
 ## peco
-## see: http://qiita.com/kp_ohnishi/items/3009e2083831af3a7c5c
-# peco-select-history () {
-#     local tac
-#     if which tac > /dev/null
-#     then
-#             tac="tac"
-#     else
-#             tac="tail -r"
-#     fi
-#     BUFFER=$(history -n 1 | \
-#     eval $tac | \
-#     peco --query "$LBUFFER")
-#     CURSOR=$#BUFFER
-#     zle clear-screen
-# }
-# zle -N peco-select-history
-# bindkey '^r' peco-select-history
-
+# see: http://qiita.com/kp_ohnishi/items/3009e2083831af3a7c5c
 # see: http://qiita.com/wada811/items/78b14181a4de0fd5b497
 function peco-select-history() {
     local tac
@@ -56,3 +79,12 @@ function peco-select-history() {
 }
 zle -N peco-select-history
 bindkey '^r' peco-select-history
+# source <(kubectl completion zsh)
+# source <(minikube completion zsh)
+
+if [ -e /usr/local/share/zsh-completions ]; then
+    fpath=(/usr/local/share/zsh-completions $fpath)
+fi
+
+# initialise completions with ZSH's compinit
+autoload -Uz compinit && compinit


### PR DESCRIPTION
# Overview

This pull request makes several improvements and cleanups to the Zsh configuration, focusing on enhanced OS-specific setup, prompt customization, and history management. The changes modernize the configuration, improve compatibility across different operating systems, and streamline the loading of completions and paths.

**OS-specific configuration and environment setup:**

* Introduced a case statement in `zsh/.zshrc` to handle OS-specific configurations, such as setting up `asdf` paths and completions for both macOS and Linux, with placeholders for other OSes. This ensures the shell environment is correctly configured based on the detected operating system.

**Prompt customization:**

* Changed the prompt initialization in `zsh/.zshrc` to use `powerlevel10k` instead of `paradox` or `sorin`, allowing for a more modern and customizable prompt.

**History and alias improvements:**

* Increased `HISTSIZE` and `SAVEHIST` in `zsh/.zshrc` for virtually unlimited command history, and added a new `gp` alias for `git pull`.

**Cleanup and removal of redundant configurations:**

* Removed deprecated or redundant `PATH` exports and commented out previously active prompt and completion lines in `.zshrc` for clarity and to avoid conflicts. [[1]](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L110-L112) [[2]](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L136-R133)

**Completions and plugin enhancements:**

* Added logic in `zsh/.zshrc` to append `/usr/local/share/zsh-completions` to `fpath` if it exists, and commented out direct sourcing of `kubectl` and `minikube` completions, likely to prevent errors if those tools are not installed.

These updates make the Zsh configuration more robust, maintainable, and portable across different development environments.